### PR TITLE
docs(dataframedeclima): update comment about location format in API call

### DIFF
--- a/dataframedeclima.ipynb
+++ b/dataframedeclima.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "id": "0273a236",
    "metadata": {},
    "outputs": [
@@ -452,7 +452,7 @@
     "\n",
     "\n",
     "API_KEY = \"8edf5a3557214b83a8d24412250109\"\n",
-    "local = \"Curitiba\"  # pode ser \"Curitiba, Brazil\" ou latitude,longitude\n",
+    "local = \"Curitiba\"  # pode ser \"Curitiba, Brazil\" ou latitude\n",
     "url = \"http://api.weatherapi.com/v1/forecast.json\"\n",
     "params = {\n",
     "    \"key\": API_KEY,\n",


### PR DESCRIPTION
Clarify that the location parameter can be either city name or latitude only, removing outdated reference to longitude